### PR TITLE
Fix for imports so it compiles properly

### DIFF
--- a/src/commander.ts
+++ b/src/commander.ts
@@ -1,4 +1,4 @@
-import commander from 'commander';
+import * as commander from 'commander';
 
 export interface Command extends commander.Command {
     forwardSubCommands(): Command;

--- a/src/service.ts
+++ b/src/service.ts
@@ -1,5 +1,5 @@
 import { Injectable, INestApplicationContext } from '@nestjs/common';
-import ora from 'ora';
+import * as ora from 'ora';
 import { Command, forwardSubCommands } from './commander';
 import { InjectCommander } from './decorators';
 
@@ -10,10 +10,12 @@ export interface WithApplicationContext {
 @Injectable()
 export class ConsoleService implements WithApplicationContext {
     protected container: INestApplicationContext;
-    constructor(@InjectCommander() protected readonly cli: Command) {}
+
+    constructor(@InjectCommander() protected readonly cli: Command) {
+    }
 
     static createSpinner(text?: string) {
-        return ora(text);
+        return ora.default(text);
     }
 
     getCli() {


### PR DESCRIPTION
This fixes the errors discussed in #18 

in [src/service.ts](/src/service.ts) it's necessary to use `ora.default` to tell the tsc compiler to use the exported constant. It seems like the typings for the package are a bit weird. An alternative fix is using `require` but that's just strange in a typescript project, in my opinion. :)