### PR TITLE
Update readme. Add app.close() before process.exit().

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,17 @@ bootstrap.init().then(async (app) => {
         await app.init();
         // boot the cli
         await bootstrap.boot();
+
+        // Use app.close() instead of process.exit() because app.close() will
+        // trigger onModuleDestroy, beforeApplicationShutdown and onApplicationShutdown.
+        // For example, in your command doing the database operation and need to close
+        // when error or finish.
+        app.close();
+
         process.exit(0);
     } catch (e) {
+        app.close();
+
         process.exit(1);
     }
 });


### PR DESCRIPTION
Add `app.close()` before `process.exit()` because `app.close()` will trigger `onModuleDestroy`, `beforeApplicationShutdown` and `onApplicationShutdown`.

The previous readme only terminates the app when the command finish using `process.exit()`. I have an issue with the database connection not terminate after the command finish. You can view the issue here [#275](https://github.com/Pop-Code/nestjs-console/issues/275)