### PR TITLE
Update README. Add await for app.close()

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ bootstrap.init().then(async (app) => {
         // trigger onModuleDestroy, beforeApplicationShutdown and onApplicationShutdown.
         // For example, in your command doing the database operation and need to close
         // when error or finish.
-        app.close();
+        await app.close();
 
         process.exit(0);
     } catch (e) {


### PR DESCRIPTION
`app.close()` returns Promise, but there is no `await` in the example.
I think it's good idea to call it with await (`await app.close()`) just like `await app.init();`.

Related: #275, #276