### PR TITLE
Add ability to provide a request and load request scoped modules

### DIFF
--- a/src/bootstrap/abstract.ts
+++ b/src/bootstrap/abstract.ts
@@ -78,9 +78,9 @@ export abstract class AbstractBootstrapConsole<
     /**
      * Activate the decorators scanner
      */
-    protected useDecorators(): this {
+    protected async useDecorators(): Promise<this> {
         const consoleModule = this.container.get(ConsoleModule);
-        consoleModule.scan(this.container, this.options.includeModules);
+        await consoleModule.scan(this.container, this.options.includeModules);
         return this;
     }
 
@@ -97,7 +97,7 @@ export abstract class AbstractBootstrapConsole<
             this.service.setContainer(this.container);
         }
         if (this.options.useDecorators) {
-            this.useDecorators();
+            await this.useDecorators();
         }
         return this.container;
     }

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -95,6 +95,8 @@ export interface ConsoleOptions {
      * The alias of this console
      */
     alias?: string;
+
+    request?: Record<string, unknown>;
 }
 
 /**

--- a/src/module.ts
+++ b/src/module.ts
@@ -19,8 +19,8 @@ export class ConsoleModule {
 
     constructor(protected readonly service: ConsoleService) {}
 
-    public scan(app: INestApplicationContext, includedModules?: unknown[]): void {
-        const scanResponse = this.scanner.scan(app, includedModules);
+    public async scan(app: INestApplicationContext, includedModules?: unknown[]): Promise<void> {
+        const scanResponse = await this.scanner.scan(app, includedModules);
         const cli = this.service.getCli();
         scanResponse.forEach(({ methods, instance, metadata }) => {
             let parent = cli;

--- a/src/test/scanner.spec.ts
+++ b/src/test/scanner.spec.ts
@@ -39,7 +39,7 @@ describe('Scanner', () => {
         }).compile();
 
         const scanner = new ConsoleScanner();
-        const scanResponse = scanner.scan(mod, [ModuleTest]);
+        const scanResponse = await scanner.scan(mod, [ModuleTest]);
 
         expect(scanResponse).toBeInstanceOf(Set);
         expect(scanResponse.size).toBe(0);
@@ -51,7 +51,7 @@ describe('Scanner', () => {
         }).compile();
 
         const scanner = new ConsoleScanner();
-        const scanResponse = scanner.scan(mod, [ModuleWithDecoratorsTest]);
+        const scanResponse = await scanner.scan(mod, [ModuleWithDecoratorsTest]);
 
         expect(scanResponse).toBeInstanceOf(Set);
 
@@ -65,7 +65,7 @@ describe('Scanner', () => {
         }).compile();
 
         const scanner = new ConsoleScanner();
-        const scanResponse = scanner.scan(mod, [ModuleWithDecoratorsTest]);
+        const scanResponse = await scanner.scan(mod, [ModuleWithDecoratorsTest]);
 
         expect(scanResponse).toBeInstanceOf(Set);
 


### PR DESCRIPTION
As mentioned in some previous issues (https://github.com/Pop-Code/nestjs-console/issues/251 https://github.com/Pop-Code/nestjs-console/issues/172), utilizing anything with a request scoped dependency causes command execution to fail. While I agree this makes sense conceptually, I think many people utilize this project to re-use functionality that was written with web-requests in mind and that many people might find it useful to be able to provide a request object and execute request-scoped code.

This PR would need additional cleanup and tests written, but I wanted to gauge you interest in merging something like this before I put more work into getting this ready. Thank you!